### PR TITLE
Use preg_replace_callback as the \e option is deprecated in PHP 5.5

### DIFF
--- a/restagent.lib.php
+++ b/restagent.lib.php
@@ -158,7 +158,7 @@ class Request {
     $fields = explode("\r\n", preg_replace('/\x0D\x0A[\x09\x20]+/', ' ', $header));
     foreach( $fields as $field ) {
       if( preg_match('/([^:]+): (.+)/m', $field, $match) ) {
-        $match[1] = preg_replace('/(?<=^|[\x09\x20\x2D])./e', 'strtoupper("\0")', strtolower(trim($match[1])));
+        $match[1] = preg_replace_callback('/(?<=^|[\x09\x20\x2D])./', function($matches){ return strtoupper($matches[0]); }, strtolower(trim($match[1])));
         if( isset($retVal[$match[1]]) ) {
           $retVal[$match[1]] = array($retVal[$match[1]], $match[2]);
         } else {


### PR DESCRIPTION
This should fix the issue in https://github.com/inadarei/restagent/issues/7